### PR TITLE
Feature/allow camelcase on unsafe lifecycle method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A bro will lint and prettify your code
 ## Installation
 
 ```
-$ yarn install @codementor/bro --dev
+$ yarn add @codementor/bro --dev
 ```
 
 To let your editor lint plugin works, you'll need to copy the `.eslintrc` from this package to your project root.

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -17,6 +17,13 @@
     "jest": true
   },
   "rules": {
+    "camelcase": ["error", {
+      "allow": [
+        "UNSAFE_componentWillMount",
+        "UNSAFE_componentWillReceiveProps",
+        "UNSAFE_componentWillUpdate"
+      ]
+    }],
     "prefer-const": ["error", {
       "destructuring": "all"
     }],

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -10,6 +10,18 @@ test('api: lintFiles', (t) => {
   })
 })
 
+test('api: allow "camelcase" on react unsafe lifecycle methods', (t) => {
+  t.plan(3)
+  standard.lintFiles(['mockReactComponentFile.js'], { cwd: 'test' }, (err, result) => {
+    result.results.forEach(res => {
+      console.log(res)
+    })
+    t.error(err, 'no error while linting')
+    t.equal(typeof result, 'object', 'result is an object')
+    t.equal(result.errorCount, 0, 'has no error')
+  })
+})
+
 test('api: lintText', (t) => {
   t.plan(3)
   standard.lintText('console.log("hi there")', (err, result) => {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -13,9 +13,6 @@ test('api: lintFiles', (t) => {
 test('api: allow "camelcase" on react unsafe lifecycle methods', (t) => {
   t.plan(3)
   standard.lintFiles(['mockReactComponentFile.js'], { cwd: 'test' }, (err, result) => {
-    result.results.forEach(res => {
-      console.log(res)
-    })
     t.error(err, 'no error while linting')
     t.equal(typeof result, 'object', 'result is an object')
     t.equal(result.errorCount, 0, 'has no error')

--- a/test/mockReactComponentFile.js
+++ b/test/mockReactComponentFile.js
@@ -1,0 +1,13 @@
+import React, { PureComponent } from 'react'
+
+class MyComponent extends PureComponent {
+  UNSAFE_componentWillMount() {}
+  UNSAFE_componentWillReceiveProps(nextProps) {}
+  UNSAFE_componentWillUpdate() {}
+
+  render() {
+    return <div>my component</div>
+  }
+}
+
+export default MyComponent

--- a/test/mockReactComponentFile.js
+++ b/test/mockReactComponentFile.js
@@ -2,7 +2,9 @@ import React, { PureComponent } from 'react'
 
 class MyComponent extends PureComponent {
   UNSAFE_componentWillMount() {}
+
   UNSAFE_componentWillReceiveProps(nextProps) {}
+
   UNSAFE_componentWillUpdate() {}
 
   render() {


### PR DESCRIPTION
react starts to throw warning message when using unsafe life cycle methods (like `componentWillMount`, `componentWillReceiveProps` and `componentWillUpdate`) starting from `16.9.0`. 

according to the official [migration doc](https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#new-deprecations), prefixing them with `UNSAFE_` will prevent them from throwing warning messages.

however this will violate the `camelcase` rule we've already applied, and will block us from upgrading react. so I customized the camelcase rule to bypass the violation.