### PR TITLE
Fix/incorrect config file location lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A bro will lint and prettify your code
 $ yarn add @codementor/bro --dev
 ```
 
-To let your editor lint plugin works, you'll need to copy the `.eslintrc` from this package to your project root.
+To let your editor lint plugin works, you'll need to copy the `eslintrc.json` from this package to your project root and rename to `.eslintrc.json`.
 ```
 $ cp node_modules/@codementor/bro/eslintrc.json ./.eslintrc
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ yarn add @codementor/bro --dev
 
 To let your editor lint plugin works, you'll need to copy the `eslintrc.json` from this package to your project root and rename to `.eslintrc.json`.
 ```
-$ cp node_modules/@codementor/bro/eslintrc.json ./.eslintrc
+$ cp node_modules/@codementor/bro/eslintrc.json ./.eslintrc.json
 ```
 
 ## Config

--- a/options.js
+++ b/options.js
@@ -8,6 +8,6 @@ module.exports = {
   homepage: pkg.homepage,
 	eslint: eslint,
 	eslintConfig: {
-		configFile: path.join(__dirname, 'eslintrc.json')
+		configFile: path.join(path.resolve('./'), '.eslintrc.json')
 	}
 }


### PR DESCRIPTION
### Why 
The rule changes to `.eslintrc` in each application folder do not wrok.

The reason why the `.eslintrc` does not work is that, in `bro`, it was configured to use the `eslintrc.json` where bro script resides(in `node_modules/@codementor/bro`), instead of the one created in each application root folder. 

