### PR TITLE
🚨 add eslint-plugin-react-hooks linter rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
     "standard",
     "standard-react",
     "standard-jsx",
-    "prettier"
+    "prettier",
+    "plugin:react-hooks/recommended"
   ],
   "plugins": [
     "react",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.29.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.5.1",
     "standard-engine": "^15.0.0-0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,6 +786,11 @@ eslint-plugin-promise@^6.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz#017652c07c9816413a41e11c30adc42c3d55ff18"
   integrity sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react@^7.29.2:
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz#2d4da69d30d0a736efd30890dc6826f3e91f3f7c"


### PR DESCRIPTION
## Issue

- https://github.com/CodementorIO/arc-next/pull/2590#discussion_r1234653864
- https://codementor.slack.com/archives/CGPGSFH7S/p1687226744888869


Due to the above PR comment discussion, we hope to add the `eslint-plugin-react-hooks` to check the useEffect dependencies rule.

## What

Add `eslint-plugin-react-hooks`